### PR TITLE
Update Cuda to 11.4.2, more modern architectures & Ubuntu 20.04 

### DIFF
--- a/dockerfiles/Dockerfile.cuda
+++ b/dockerfiles/Dockerfile.cuda
@@ -5,16 +5,20 @@
 # Dockerfile to run ONNXRuntime with CUDA, CUDNN integration
 
 # nVidia cuda 11.4 Base Image
-FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-devel-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-devel-ubuntu20.04
+#FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
+ENV	    DEBIAN_FRONTEND=nonintercative
 MAINTAINER Changming Sun "chasun@microsoft.com"
 ADD . /code
 
 ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 RUN apt-get update && apt-get install -y --no-install-recommends python3-dev ca-certificates g++ python3-numpy gcc make git python3-setuptools python3-wheel python3-pip aria2 && aria2c -q -d /tmp -o cmake-3.21.0-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.0/cmake-3.21.0-linux-x86_64.tar.gz && tar -zxf /tmp/cmake-3.21.0-linux-x86_64.tar.gz --strip=1 -C /usr
 
-RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=37;50;52;60;70'
+RUN cd /code && /bin/bash ./build.sh --skip_submodule_sync --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu/ --use_cuda --config Release --build_wheel --update --build --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) 'CMAKE_CUDA_ARCHITECTURES=52;60;61;70;75;86'
 
-FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
+#FROM nvidia/cuda:11.4.2-devel-ubuntu18.04
+ENV	    DEBIAN_FRONTEND=nonintercative
 COPY --from=0 /code/build/Linux/Release/dist /root
 COPY --from=0 /code/dockerfiles/LICENSE-IMAGE.txt /code/LICENSE-IMAGE.txt
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Update to Cuda 11.4.2 and support latest Cuda hardware architectures

